### PR TITLE
Fix obstacle size + Flash compilation

### DIFF
--- a/source/Obstacle.hx
+++ b/source/Obstacle.hx
@@ -8,7 +8,7 @@ class Obstacle extends FlxSprite
 	private var dead:Bool;
 	private var player:Player;
 
-	private static var TILE_SIZE:Int = 16;
+	private static var TILE_SIZE:Int = 18;
 
 	public function new(x:Float, y:Float, player:Player)
 	{
@@ -16,7 +16,7 @@ class Obstacle extends FlxSprite
 		this.player = player;
 
 		//loadGraphicFromTexture("assets/images/obstacles2.png");
-		loadGraphic("assets/images/obstacles2.png", TILE_SIZE, TILE_SIZE);
+		loadGraphic("assets/images/obstacles2.png", true, TILE_SIZE, TILE_SIZE);
 	}
 
 	/**


### PR DESCRIPTION
I noticed that the project doesn't compile to Flash (with Haxe 3.4.0 at least):

>source/Obstacle.hx:19: characters 2-67 : Cannot skip non-nullable argument Animated

I believe this also fixes a bug where the full spritesheet would show for obstacles, instead of just a single obstacle:

Before:

![](http://i.imgur.com/ckiZoe7.png)

After:

![](http://i.imgur.com/SfQaet2.png)

`TILE_SIZE` also was too small (16 instead of 18).